### PR TITLE
ci: migrate from OSSRH to Sonatype central

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,5 +25,5 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
-          ORG_GRADLE_PROJECT_ossrhUsername: ${{ secrets.OSSRH_USERNAME }}
-          ORG_GRADLE_PROJECT_ossrhPassword: ${{ secrets.OSSRH_PASSWORD }}
+          ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ export ORG_GRADLE_PROJECT_signingPassword=<GPG signing key passphrase>
 
 If you are having issues setting the multiline signing key as an environment variable, you can use Base64 encoding.
 
-Additionally, you will need credentials for [https://s01.oss.sonatype.org](https://s01.oss.sonatype.org). Configure
+Additionally, you will need credentials for [https://central.sonatype.com](https://central.sonatype.com). Configure
 these in `~/.gradle/gradle.properties` like this:
 
 ```
-ossrhUsername=<username>
-ossrhPassword=<password>
+sonatypeUsername=<username>
+sonatypePassword=<password>
 ```
 
 Once everything is set up, you should be able to publish snapshots using
@@ -153,7 +153,3 @@ Once everything is set up, you should be able to publish snapshots using
 ```
 ./gradlew publish
 ```
-
-If your [https://s01.oss.sonatype.org](https://s01.oss.sonatype.org) credentials do not have sufficient privileges,
-create a ticket for manual approval, as described here:
-[https://central.sonatype.org/publish/manage-permissions/](https://central.sonatype.org/publish/manage-permissions/)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,19 +69,19 @@ publishing {
 			repositories {
 				maven {
 					credentials {
-						// Configure by setting the ORG_GRADLE_PROJECT_ossrhUsername environment variable.
-						val ossrhUsername: String? by project
-						username = ossrhUsername
+						// Configure by setting the ORG_GRADLE_PROJECT_sonatypeUsername environment variable.
+						val sonatypeUsername: String? by project
+						username = sonatypeUsername
 
-						// Configure by setting the ORG_GRADLE_PROJECT_ossrhPassword environment variable.
-						val ossrhPassword: String? by project
-						password = ossrhPassword
+						// Configure by setting the ORG_GRADLE_PROJECT_sonatypePassword environment variable.
+						val sonatypePassword: String? by project
+						password = sonatypePassword
 					}
 
 					url = if (version.endsWith("-SNAPSHOT")) {
-						uri("https://s01.oss.sonatype.org/content/repositories/snapshots/")
+						uri("https://central.sonatype.com/repository/maven-snapshots/")
 					} else {
-						uri("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
+						uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
 					}
 				}
 			}


### PR DESCRIPTION
I already created the new secrets in GitHub (and deleted the old ones).