### PR TITLE
test: add JUnit launcher dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
 	testImplementation("org.testcontainers:rabbitmq:1.21.2")
 	testImplementation("org.junit.jupiter:junit-jupiter-api")
 	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
+	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 }
 
 java {


### PR DESCRIPTION
This is required for the Spring Boot 3.5 update.